### PR TITLE
Hide help command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,16 +18,17 @@ program
     .option('-p, --path [scanDirectory]', 'The path of the directory you want to analyse')
     .option('-e, --evolution [days]', 'Get the evolution of the debt since X days')
     .option('-f, --filter [type]', 'Get the files that are concerned by a particular debt type')
-    .parse(process.argv);
 
-console.log(
-    chalk.green(
-        figlet.textSync('TYRION', { horizontalLayout: 'full' })
-    )
-);
+program.on('--help', function() {
+    console.log('');
+    console.log(
+        chalk.green(
+            figlet.textSync('TYRION', { horizontalLayout: 'full' })
+        ));
+});
 
-console.info(program.helpInformation());
-
+program.parse(process.argv);
+            
 let scanDirectory = program.path;
 
 if (!scanDirectory) {


### PR DESCRIPTION
Default behaviour :
 
<img width="722" alt="Capture d’écran 2019-05-22 à 10 02 21" src="https://user-images.githubusercontent.com/477945/58157545-cedcb000-7c78-11e9-9d82-d84175e0dcd6.png">

Help menu : 

<img width="724" alt="Capture d’écran 2019-05-22 à 10 02 42" src="https://user-images.githubusercontent.com/477945/58157570-de5bf900-7c78-11e9-8b39-4ba6fe114626.png">

Note : couldn't put TYRION before help...

Closes #13 