### PR TITLE
Add functionality for an ignored path in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ It will compare the type and the string you pass as an argument after filter.
 
 Example: `tyrion -p ./src --filter bug`
 
+
+## Ignore paths
+
+You can ignore files containing certain strings by using the `"ignore"`option in the config file:
+```
+"ignore": "node_modules"
+```
+
+Todo: add capability for multiple ignore paths in array (currently only takes singular string)
+
 ## Contribute
 
 1. Install the dependencies `npm i`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1057,8 +1057,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1079,14 +1078,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1101,20 +1098,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1231,8 +1225,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1244,7 +1237,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1259,7 +1251,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1267,14 +1258,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1293,7 +1282,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1374,8 +1362,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1387,7 +1374,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1473,8 +1459,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1510,7 +1495,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1530,7 +1514,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1575,14 +1558,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,9 @@ if (!scanDirectory) {
 
 const config = new Config(scanDirectory)
 
-const collector = new Collector(scanDirectory, program.filter, config.getPrices());
+const collector = new Collector(scanDirectory, program.filter, config.getPrices(), config.getIgnored());
+
+export const ignored = config.getIgnored()
 
 if (program.evolution){
     const historyNumberOfDays = isNaN(parseInt(program.evolution)) ? HISTORY_DEFAULT_NUMBER_OF_DAYS : program.evolution;

--- a/src/services/collector.ts
+++ b/src/services/collector.ts
@@ -7,6 +7,7 @@ import dateHelper from "../utils/dateHelper";
 import fs from 'fs';
 import path from 'path';
 import {Pricer} from "./pricer";
+import {ignored} from "../index"
 
 const glob = require("glob");
 const nodeGit = require("nodegit");
@@ -15,27 +16,29 @@ export default class Collector {
     scanningPath: string;
     pricer: Pricer;
     filter: string;
-    constructor(scanningPath: string, filter:string, prices: any) {
+    withoutIgnored: string;
+
+    constructor(scanningPath: string, filter:string, prices: any, withoutIgnored: string) {
         this.scanningPath = scanningPath;
         this.filter = filter;
         this.pricer = new Pricer(prices);
+        this.withoutIgnored = withoutIgnored;
     }
 
     async collect(): Promise<Debt> {
+        const ignorePath = ignored
         const allNotHiddenFiles = this.scanningPath + '/**/*.*';
         const notHiddenFiles = glob.sync(allNotHiddenFiles, {'nodir': true});
-
         const allHiddenFiles = this.scanningPath + '/**/.*';
         const hiddenFiles = glob.sync(allHiddenFiles, {'nodir': true});
 
         const allFiles = notHiddenFiles.concat(hiddenFiles);
         const debt = new Debt(this.pricer);
-
-        for (let fileName of allFiles) {
+        const withoutIgnored = allFiles.filter((path: string) => !path.includes(ignorePath))
+        for (let fileName of withoutIgnored) {
             const file = fs.readFileSync(fileName, 'utf-8');
             this.parseFile(file, fileName, debt);
         }
-
         return debt;
     }
 

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -17,6 +17,7 @@ export default class Config {
       const defaultConfigFile = fs.readFileSync(path.resolve(__dirname, '../../.tyrion-config.json'), 'utf-8');
       const defaultConfig = JSON.parse(defaultConfigFile);
 
+
       const projectConfigPath = this.path + '/.tyrion-config.json';
 
       if (fs.existsSync(projectConfigPath)) {
@@ -27,7 +28,7 @@ export default class Config {
         this.config = defaultConfig;
       }
     }
-    
+
     getPrices(): any {
       if (!this.config) {
         this.loadConfigs()
@@ -36,7 +37,7 @@ export default class Config {
       console.info('\nHere are the pricing for each debt item of your project:\n', this.config.pricer);
       return this.config.pricer;
     }
-    
+
     getStandard(): number {
       if (!this.config) {
         this.loadConfigs()
@@ -45,5 +46,12 @@ export default class Config {
       console.info('\nStandard: ', this.config.standard);
       return this.config.standard;
     }
-}
 
+    getIgnored(): any{
+        if (!this.config) {
+            this.loadConfigs()
+        }
+        console.info('\n Ignored: ', this.config.ignore);
+        return this.config.ignore;
+    }
+}


### PR DESCRIPTION
# What does this PR propose? 

This PR proposes an 'ignore path' functionality. 

## Why?  🤔

At CRC we are using Tyrion for our Kaizen (Kudos! It works really well!). We have run into some issues surrounding our documentation and coverage directory: 

- We have documented how to properly use Tyrion, and as a result, Tyrion has recognised our readme example as a 100 point debt! 
- When we run our Jest test library, the coverage creates a snapshot and duplicates many of the already-created Tyrion cases. 

## How? 🛠

I have added 'ignore' as an option to the Tyrion config file. The `ignore` variable is ingested, and the `ScanningPath` variable is filtered to remove any files that include the `ignore` variable. 

## Limitations

Currently the `ignore` variable can only be one string. I am currently looking at supporting arrays to allow for multiple 'banned' paths. Any ideas? 

Merci!