### PR TITLE
Add fallback config file in current execution directory

### DIFF
--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -17,25 +17,19 @@ export default class Config implements ConfigInterface {
   public constructor(directoryPath: string) {
     const defaultConfigFile = fs.readFileSync(path.resolve(__dirname, '../../.tyrion-config.json'), 'utf-8');
     const defaultConfig = JSON.parse(defaultConfigFile) as TyrionConfigInterface;
-    const projectConfigPath = directoryPath + '/.tyrion-config.json';
+    const scanDirConfigPath = directoryPath + '/.tyrion-config.json';
+    const fallbackConfigPath = './.tyrion-config.json';
 
-    if (fs.existsSync(projectConfigPath)) {
-      const projectConfigFile = fs.readFileSync(projectConfigPath, 'utf-8');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const projectConfig = JSON.parse(projectConfigFile.toString());
-
-      if (Object.prototype.hasOwnProperty.call(projectConfig, 'pricer')) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        const projectConfigPricer = projectConfig['pricer'];
-        // Ensure that the prices are numbers and not strings
-        for (const key in projectConfigPricer) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          projectConfigPricer[key] = parseInt(projectConfigPricer[key]);
-        }
-      }
+    if (fs.existsSync(scanDirConfigPath)) {
+      const projectConfig = this.readConfigFile(scanDirConfigPath);
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       this.config = Object.assign(defaultConfig, projectConfig);
+    } else if (fs.existsSync(fallbackConfigPath)) {
+      const fallbackProjectConfig = this.readConfigFile(fallbackConfigPath);
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      this.config = Object.assign(defaultConfig, fallbackProjectConfig);
     } else {
       this.config = defaultConfig;
     }
@@ -44,5 +38,23 @@ export default class Config implements ConfigInterface {
     this.standard = this.config.standard;
     //TODO bug "When an ignorePath is specified inside a non root directory then the ignorepath is the wrong one
     this.ignorePaths = this.config.ignorePath;
+  }
+
+  private readConfigFile(filePath: string): TyrionConfigInterface {
+    const configFile = fs.readFileSync(filePath, 'utf-8');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const projectConfig = JSON.parse(configFile.toString());
+
+    if (Object.prototype.hasOwnProperty.call(projectConfig, 'pricer')) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+      const projectConfigPricer = projectConfig['pricer'];
+      // Ensure that the prices are numbers and not strings
+      for (const key in projectConfigPricer) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        projectConfigPricer[key] = parseInt(projectConfigPricer[key]);
+      }
+    }
+
+    return projectConfig as TyrionConfigInterface;
   }
 }


### PR DESCRIPTION
When executing Tyrion, the program will now look for a `.tyrion-config.json` file in the scanDir given by `-p` , then it will fall back on a `.tyrion-config.json` file in the current directory. (the one the program is executed from). And if there are no custom config file, it will use the default config file that ships with the library.

This allows to keep the existing behavior and allows having only one project-wide custom configuration file and being able to scan different subFolders of the project.